### PR TITLE
Fix insert-then-delete test

### DIFF
--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -102,7 +102,9 @@ pInsertIdem node ring =
   R.insert node (R.insert node ring) == R.insert node ring
 
 pInsertDelete :: Int -> IRing -> Bool
-pInsertDelete node ring = ring == R.delete node (R.insert node ring)
+pInsertDelete node ring
+    | (R.member node ring) = True -- if item is in ring - it's removing will break the ring
+    | otherwise = ring == R.delete node (R.insert node ring)
 
 pDeleteNonMember :: Int -> IRing -> Property
 pDeleteNonMember node ring =


### PR DESCRIPTION
A Delete after Insert test will not change the ring only if inserting node is not available in a ring.
